### PR TITLE
Loop over responses only once, loop over metrics every time.

### DIFF
--- a/main.go
+++ b/main.go
@@ -83,13 +83,15 @@ func main() {
 			)
 		}
 
-		// Go through each QueryMetric and grab data from associated responses
-		for _, query := range combinedQueryMetrics.List {
-			for i := len(responses) - 1; i >= 0; i-- {
-				if query.SeqNumbers[responses[i].Ack] {
+		// Go through each response and match it to a QueryMetric
+		// This could be improved by implementing some sort of sequence number
+		// cache, so that we could just ask it 'What QueryMetric does this seq
+		// belong to?', instead of looping over the metrics every time.
+		for _, response := range responses {
+			for _, query := range combinedQueryMetrics.List {
+				if query.SeqNumbers[response.Ack] {
 					query.TotalResponsePackets += 1
-					query.TotalNetBytes += uint64(len(responses[i].Payload))
-					responses = append(responses[:i], responses[i+1:]...)
+					query.TotalNetBytes += uint64(len(response.Payload))
 				}
 			}
 		}


### PR DESCRIPTION
If I'm understanding the current code correctly, we loop over all (or at
least most) of the responses for every single QueryMetric, in order to
associate responses with metrics. This leads to O(n^2) complexity, and
causes it to take a long time to process more and more packets.

This switches over to running through the responses once, and iterating
over the metrics to find the associated Seq. While I think this is still
actually O(n^2) complexity, it's definitely less intensive.

Benchmarks show similar performance in the double digit MB, for a 600MB
run there was an average 15s improvement, and I didn't ever have the
patience to run it for anything in the GB.

Results are also identical.
