### PR TITLE
Add simple AssociatePgPackets test

### DIFF
--- a/processing/processing.go
+++ b/processing/processing.go
@@ -57,8 +57,7 @@ func ExtractPGPackets(handle *pcap.Handle) (*metrics.QueryMetrics, []*ResponsePa
 				DstIP: ip.DstIP,
 				Ack:   tcp.Ack,
 				Size:  uint64(len(tcp.Payload)),
-			},
-			)
+			})
 		}
 	}
 	return combinedQueryMetrics, responses

--- a/processing/processing_test.go
+++ b/processing/processing_test.go
@@ -1,0 +1,39 @@
+package processing
+
+import (
+	"net"
+	"testing"
+
+	"github.com/procore/pgnetdetective/metrics"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAssociatePGPackets(t *testing.T) {
+	metric := &metrics.QueryMetric{
+		Query: "select * from table",
+		QueryNetUniqueIDs: []*metrics.QueryNetUniqueID{
+			&metrics.QueryNetUniqueID{net.IPv4(111, 111, 111, 111), uint32(43212)},
+		},
+	}
+
+	combinedQueryMetrics := metrics.NewQueryMetrics()
+	combinedQueryMetrics.Add(metric)
+
+	responses := []*ResponsePacket{
+		&ResponsePacket{
+			DstIP: net.IPv4(111, 111, 111, 111),
+			Ack:   uint32(43212),
+			Size:  uint64(1000),
+		},
+		&ResponsePacket{
+			DstIP: net.IPv4(111, 111, 111, 111),
+			Ack:   uint32(43212),
+			Size:  uint64(1000),
+		},
+	}
+
+	AssociatePGPackets(combinedQueryMetrics, responses)
+
+	assert.Equal(t, uint64(2), combinedQueryMetrics.List[0].TotalResponsePackets)
+	assert.Equal(t, uint64(2000), combinedQueryMetrics.List[0].TotalNetworkLoad)
+}


### PR DESCRIPTION
In pursuit of relearning how to Go again, added a super simple AssociatePgPackets test.

@ajvb Are there any continuous integration services that support Golang really well, or should we just do custom install steps for CircleCI since that's where the majority of our CI happens?
